### PR TITLE
Allow events to be filtered

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -9,6 +9,7 @@ import ZoomControl from 'components/controls/ZoomControl'
 import IncidentLayer from './layers/IncidentLayer'
 import { LatLngBoundsLiteral } from 'leaflet'
 import CategoryControl from './controls/CategoryControl'
+import YearControl from './controls/YearControl'
 
 interface MapProps {
   apiKey: string
@@ -37,6 +38,8 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
   const [filters, setFilters] = useState<MarkerFilters>({
     hideCategories: [],
     hideTypes: [],
+    startYear: null,
+    endYear: null,
   })
   const [tmpSelected, setTmpSelected] = useState<boolean>(false)
   const markersLayer = useRef(null)
@@ -150,6 +153,7 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
       {/* <LegendControl selectedStakeholder={selectedStakeholder} /> 
        <SearchControl layerRef={markersLayer} />*/}
       <CategoryControl data={data} filters={filters} setFilters={setFilters} />
+      <YearControl data={data} filters={filters} setFilters={setFilters} />
       <ZoomControl zoomLevel={2} />
       <SetInitialBounds />
     </MapContainer>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -154,7 +154,7 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
        <SearchControl layerRef={markersLayer} />*/}
       <CategoryControl data={data} filters={filters} setFilters={setFilters} />
       <YearControl data={data} filters={filters} setFilters={setFilters} />
-      <ZoomControl zoomLevel={2} />
+      <ZoomControl zoomLevel={2} setFilters={setFilters} />
       <SetInitialBounds />
     </MapContainer>
   )

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -8,6 +8,7 @@ import ZoomControl from 'components/controls/ZoomControl'
 // import LegendControl from './controls/LegendControl'
 import IncidentLayer from './layers/IncidentLayer'
 import { LatLngBoundsLiteral } from 'leaflet'
+import CategoryControl from './controls/CategoryControl'
 
 interface MapProps {
   apiKey: string
@@ -33,7 +34,10 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
     [90, 180],
   ]
   const [selectedIncidentID, setSelectedIncidentID] = useState<keyof DB['Incidents'] | null>(null)
-  const [filters, setFilters] = useState<MarkerFilters>({})
+  const [filters, setFilters] = useState<MarkerFilters>({
+    hideCategories: [],
+    hideTypes: [],
+  })
   const [tmpSelected, setTmpSelected] = useState<boolean>(false)
   const markersLayer = useRef(null)
   const [name, setName] = useState<Incident['name']>('')
@@ -144,8 +148,8 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
         deleteSelectedIncident={deleteSelectedIncident}
       />
       {/* <LegendControl selectedStakeholder={selectedStakeholder} /> 
-       <SearchControl layerRef={markersLayer} />
-      <TagControl stakeholders={stakeholders} layerRef={markersLayer} /> */}
+       <SearchControl layerRef={markersLayer} />*/}
+      <CategoryControl data={data} filters={filters} setFilters={setFilters} />
       <ZoomControl zoomLevel={2} />
       <SetInitialBounds />
     </MapContainer>

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { MapContainer, TileLayer, useMap } from 'react-leaflet'
-import { DB, Incident } from 'types'
+import { DB, Incident, MarkerFilters } from 'types'
 // import SearchControl from 'components/controls/SearchControl'
 import IncidentPanel from 'components/controls/IncidentPanel'
 import ZoomControl from 'components/controls/ZoomControl'
@@ -33,6 +33,7 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
     [90, 180],
   ]
   const [selectedIncidentID, setSelectedIncidentID] = useState<keyof DB['Incidents'] | null>(null)
+  const [filters, setFilters] = useState<MarkerFilters>({})
   const [tmpSelected, setTmpSelected] = useState<boolean>(false)
   const markersLayer = useRef(null)
   const [name, setName] = useState<Incident['name']>('')
@@ -118,6 +119,7 @@ const Map: React.FC<MapProps> = ({ apiKey, data, isAdmin, addIncident, deleteInc
         setTmpLocation={setLocation}
         tmpSelected={tmpSelected}
         setTmpSelected={setTmpSelected}
+        filters={filters}
       />
       <IncidentPanel
         data={data}

--- a/src/components/controls/CategoryControl.tsx
+++ b/src/components/controls/CategoryControl.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react'
+
+import Control from 'react-leaflet-custom-control'
+import { DB, MarkerFilters } from 'types'
+
+interface TagControlProps {
+  data: DB
+  filters: MarkerFilters
+  setFilters: React.Dispatch<React.SetStateAction<MarkerFilters>>
+}
+
+const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters }) => {
+  const [isDropdownVisible, setDropdownVisible] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      setDropdownVisible(false)
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
+  const handleCategoryCheckboxChange = (id: string, checked: boolean) => {
+    console.log('handleCategoryCheckboxChange', id, checked)
+    if (checked) {
+      setFilters((filters) => ({
+        ...filters,
+        hideCategories: filters.hideCategories.filter((catID) => catID !== id),
+      }))
+    } else {
+      setFilters((filters) => ({
+        ...filters,
+        hideCategories: [...filters.hideCategories, id],
+      }))
+    }
+  }
+
+  const handleCategorySelectAll = (checked: boolean) => {
+    if (checked) {
+      setFilters((filters) => ({
+        ...filters,
+        hideCategories: [],
+      }))
+    } else {
+      setFilters((filters) => ({
+        ...filters,
+        hideCategories: Object.keys(data.Categories),
+      }))
+    }
+  }
+
+  return (
+    <Control prepend position="topleft">
+      <div className="leaflet-bar relative rounded font-proxima-nova">
+        <a
+          className="leaflet-control-zoom-in rounded"
+          title={'Tags'}
+          role="button"
+          onClick={(e) => {
+            setDropdownVisible(!isDropdownVisible)
+            e.preventDefault()
+          }}
+        >
+          {/* ☰ */}
+          &#x2630;
+        </a>
+        {isDropdownVisible && (
+          <div
+            ref={dropdownRef}
+            className="absolute left-10 top-0 box-border w-60 rounded border-2 border-shade-01 border-opacity-40 bg-white bg-opacity-90"
+          >
+            <div className="flex flex-row justify-between">
+              <div className="text-md m-1 font-semibold">Actividades</div>
+              <div className="mx-1 flex flex-row justify-center align-middle">
+                <label htmlFor="all" className="mx-2 mt-[5px]">
+                  Seleccionar todo
+                </label>
+                <input
+                  type="checkbox"
+                  name="all"
+                  checked={Object.keys(filters.hideCategories).length === 0}
+                  onChange={(e) => handleCategorySelectAll(e.target.checked)}
+                />
+              </div>
+            </div>
+            <div className="h-max overflow-y-auto">
+              {Object.entries(data.Categories).map(([id, { name, color }]) => (
+                <div key={id} className="flex items-center border-b border-b-tint-01 p-1 last-of-type:border-0 hover:bg-tint-02">
+                  <input
+                    type="checkbox"
+                    name={id}
+                    id={id}
+                    checked={!filters.hideCategories?.includes(id)}
+                    onChange={(e) => handleCategoryCheckboxChange(id, e.target.checked)}
+                    className="mr-2"
+                  />
+                  <label htmlFor={id} className="w-full">
+                    {name}
+                  </label>
+                  <div className="ml-auto h-4 w-4 flex-shrink-0 rounded-full border border-harvard-slate" style={{ backgroundColor: color }} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </Control>
+  )
+}
+
+export default CategoryControl

--- a/src/components/controls/CategoryControl.tsx
+++ b/src/components/controls/CategoryControl.tsx
@@ -71,10 +71,7 @@ const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters 
           &#x2630;
         </a>
         {isDropdownVisible && (
-          <div
-            ref={dropdownRef}
-            className="absolute left-10 top-0 box-border w-60 rounded border-2 border-shade-01 border-opacity-40 bg-white bg-opacity-90"
-          >
+          <div ref={dropdownRef} className="leaflet-bar absolute -top-0.5 left-10 box-content w-60 rounded bg-tint-02/60 shadow-lg">
             <div className="flex flex-row justify-between">
               <div className="text-md m-1 font-semibold">Actividades</div>
               <div className="mx-1 flex flex-row justify-center align-middle">

--- a/src/components/controls/CategoryControl.tsx
+++ b/src/components/controls/CategoryControl.tsx
@@ -55,9 +55,20 @@ const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters 
     }
   }
 
+  const typesByCategory = Object.entries(data.Types).reduce(
+    (acc, [typeID, type]) => {
+      if (!acc[type.categoryID]) {
+        acc[type.categoryID] = []
+      }
+      acc[type.categoryID].push({ typeID, name: type.name })
+      return acc
+    },
+    {} as { [key: string]: { typeID: string; name: string }[] }
+  )
+
   return (
     <Control prepend position="topleft">
-      <div className="leaflet-bar relative rounded font-proxima-nova">
+      <div className="leaflet-bar relative rounded">
         <a
           className="leaflet-control-zoom-in rounded"
           title={'Tags'}
@@ -71,9 +82,9 @@ const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters 
           &#x2630;
         </a>
         {isDropdownVisible && (
-          <div ref={dropdownRef} className="leaflet-bar absolute -top-0.5 left-10 box-content w-60 rounded bg-tint-02/60 shadow-lg">
+          <div ref={dropdownRef} className="leaflet-bar absolute -top-0.5 left-10 box-content h-96 w-60 rounded bg-tint-02/60 shadow-lg">
             <div className="flex flex-row justify-between">
-              <div className="text-md m-1 font-semibold">Actividades</div>
+              <div className="m-1 text-base font-semibold">Actividades</div>
               <div className="mx-1 flex flex-row justify-center align-middle">
                 <label htmlFor="all" className="mx-2 mt-[5px]">
                   Seleccionar todo
@@ -88,7 +99,7 @@ const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters 
             </div>
             <div className="h-max overflow-y-auto">
               {Object.entries(data.Categories).map(([id, { name, color }]) => (
-                <div key={id} className="flex items-center border-b border-b-tint-01 p-1 last-of-type:border-0 hover:bg-tint-02">
+                <div key={id} className="mx-1 flex items-center border-b py-1 last-of-type:border-0 hover:bg-tint-02">
                   <input
                     type="checkbox"
                     name={id}
@@ -101,6 +112,48 @@ const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters 
                     {name}
                   </label>
                   <div className="ml-auto h-4 w-4 flex-shrink-0 rounded-full border border-harvard-slate" style={{ backgroundColor: color }} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {/* Incident types */}
+        {isDropdownVisible && (
+          <div ref={dropdownRef} className="leaflet-bar absolute -top-0.5 left-72 box-content h-96 w-80 rounded bg-tint-02/60 shadow-lg">
+            <div className="flex h-8 flex-row justify-between">
+              <div className="m-1 text-base font-semibold">Tipos de eventos</div>
+              <div className="mx-1 flex flex-row justify-center align-middle">
+                <label htmlFor="all" className="mx-2 mt-[5px]">
+                  Seleccionar todo
+                </label>
+                <input
+                  type="checkbox"
+                  name="all"
+                  checked={Object.keys(filters.hideCategories).length === 0}
+                  onChange={(e) => handleCategorySelectAll(e.target.checked)}
+                />
+              </div>
+            </div>
+            <div className="h-[calc(100%-2rem)] overflow-y-auto px-1">
+              {Object.entries(data.Categories).map(([catID, { name: catName }]) => (
+                <div key={catID}>
+                  {catName}
+                  {typesByCategory[catID]?.map(({ typeID, name: typeName }) => (
+                    <div key={typeID} className="flex items-center border-b border-b-tint-01 p-1 last-of-type:border-0 hover:bg-tint-02">
+                      <input
+                        type="checkbox"
+                        name={typeID}
+                        id={typeID}
+                        checked={!filters.hideCategories?.includes(typeID)}
+                        onChange={(e) => handleCategoryCheckboxChange(typeID, e.target.checked)}
+                        className="mr-2"
+                      />
+                      <label htmlFor={typeID} className="w-full">
+                        {typeName}
+                      </label>
+                    </div>
+                  ))}
+                  <hr />
                 </div>
               ))}
             </div>

--- a/src/components/controls/CategoryControl.tsx
+++ b/src/components/controls/CategoryControl.tsx
@@ -3,13 +3,13 @@ import React, { useEffect, useRef, useState } from 'react'
 import Control from 'react-leaflet-custom-control'
 import { DB, MarkerFilters } from 'types'
 
-interface TagControlProps {
+interface YearControlProps {
   data: DB
   filters: MarkerFilters
   setFilters: React.Dispatch<React.SetStateAction<MarkerFilters>>
 }
 
-const CategoryControl: React.FC<TagControlProps> = ({ data, filters, setFilters }) => {
+const CategoryControl: React.FC<YearControlProps> = ({ data, filters, setFilters }) => {
   const [isDropdownVisible, setDropdownVisible] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 

--- a/src/components/controls/IncidentPanel.tsx
+++ b/src/components/controls/IncidentPanel.tsx
@@ -69,7 +69,7 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({
       key={'overlay'}
       className={`${
         incident || tmpSelected ? 'w-[100%] md:w-[400px]' : 'w-0'
-      } duration-400 fixed left-0 z-[1000] box-border h-screen cursor-default overflow-y-auto bg-tint-02 bg-opacity-60 !font-proxima-nova shadow-lg backdrop-blur-sm transition-all duration-100`}
+      } duration-400 fixed left-0 z-[1000] box-border h-screen cursor-default overflow-y-auto rounded-e-xl bg-tint-02/60 !font-proxima-nova shadow-lg backdrop-blur-sm transition-all duration-100`}
       onMouseEnter={disableZoom}
       onMouseLeave={enableZoom}
     >

--- a/src/components/controls/IncidentPanel.tsx
+++ b/src/components/controls/IncidentPanel.tsx
@@ -89,11 +89,14 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({
               </div>
               <div className="font-merriweather text-base">
                 <div className="mb-4 text-sm text-shade-02">
-                  Fecha: {incident.dateString}
+                  {incident.dateString && (
+                    <>
+                      Fecha: {incident.dateString} <br />
+                    </>
+                  )}
+                  Actividad: {data.Categories[data.Types[incident.typeID].categoryID].name}
                   <br />
                   Tipo de evento: {data.Types[incident.typeID].name}
-                  <br />
-                  Actividad: {data.Categories[data.Types[incident.typeID].categoryID].name}
                 </div>
 
                 <div className="mb-6 text-shade-01">{incident.description}</div>

--- a/src/components/controls/YearControl.tsx
+++ b/src/components/controls/YearControl.tsx
@@ -65,7 +65,7 @@ const YearControl: React.FC<YearControlProps> = ({ data, filters, setFilters }) 
             className="leaflet-bar absolute -bottom-0.5 left-10 box-content h-24 w-[calc(100vw-4.25rem)] rounded bg-tint-02/80 shadow-lg backdrop-blur-sm"
           >
             <label className="block text-center text-xl font-semibold" htmlFor="year">
-              Year
+              Año
             </label>
             <div className="flex w-full items-center justify-center gap-2 p-2">
               <button
@@ -80,10 +80,12 @@ const YearControl: React.FC<YearControlProps> = ({ data, filters, setFilters }) 
                 min={minYear}
                 max={maxYear}
                 value={filters.startYear || minYear}
+                onMouseEnter={() => (filters.endYear == null ? handleRangeUpdate(minYear) : null)}
                 onChange={(e) => handleRangeUpdate(parseInt(e.target.value))}
                 className="flex-grow"
               />
               {maxYear}
+              <span className="text-lg font-semibold">{filters.startYear || minYear}</span>
             </div>
           </div>
         )}

--- a/src/components/controls/YearControl.tsx
+++ b/src/components/controls/YearControl.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+import Control from 'react-leaflet-custom-control'
+import { DB, MarkerFilters } from 'types'
+
+interface YearControlProps {
+  data: DB
+  filters: MarkerFilters
+  setFilters: React.Dispatch<React.SetStateAction<MarkerFilters>>
+}
+
+const YearControl: React.FC<YearControlProps> = ({ data, filters, setFilters }) => {
+  const [isDropdownVisible, setDropdownVisible] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      setDropdownVisible(false)
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
+  const minYear = Math.min(...Object.values(data.Incidents).map((e) => new Date(e.dateString).getFullYear()))
+  const maxYear = Math.max(...Object.values(data.Incidents).map((e) => new Date(e.dateString).getFullYear()))
+
+  const handleResetRange = () => {
+    setFilters((filters) => ({
+      ...filters,
+      startYear: null,
+      endYear: null,
+    }))
+  }
+  const handleRangeUpdate = (newYear: number) => {
+    setFilters((filters) => ({
+      ...filters,
+      startYear: newYear,
+      endYear: newYear,
+    }))
+  }
+
+  return (
+    <Control prepend position="bottomleft">
+      <div className="leaflet-bar relative rounded">
+        <a
+          className="leaflet-control-zoom-in rounded"
+          title={'Tags'}
+          role="button"
+          onClick={(e) => {
+            setDropdownVisible(!isDropdownVisible)
+            e.preventDefault()
+          }}
+        >
+          {/* ⧗ */}
+          &#x029D7;
+        </a>
+        {isDropdownVisible && (
+          <div
+            ref={dropdownRef}
+            className="leaflet-bar absolute -bottom-0.5 left-10 box-content h-24 w-[calc(100vw-4.25rem)] rounded bg-tint-02/80 shadow-lg backdrop-blur-sm"
+          >
+            <label className="block text-center text-xl font-semibold" htmlFor="year">
+              Year
+            </label>
+            <div className="flex w-full items-center justify-center gap-2 p-2">
+              <button
+                className="rounded border-2 border-tint-01 bg-white px-2 py-1 text-lg hover:bg-tint-02 active:bg-tint-01"
+                onClick={handleResetRange}
+              >
+                Reset
+              </button>
+              {minYear}
+              <input
+                type="range"
+                min={minYear}
+                max={maxYear}
+                value={filters.startYear || minYear}
+                onChange={(e) => handleRangeUpdate(parseInt(e.target.value))}
+                className="flex-grow"
+              />
+              {maxYear}
+            </div>
+          </div>
+        )}
+      </div>
+    </Control>
+  )
+}
+
+export default YearControl

--- a/src/components/controls/ZoomControl.tsx
+++ b/src/components/controls/ZoomControl.tsx
@@ -1,15 +1,17 @@
 import { useMap } from 'react-leaflet'
 import Control from 'react-leaflet-custom-control'
+import { MarkerFilters } from 'types'
 
 interface ZoomControlProps {
   zoomInTitle?: string
   zoomOutTitle?: string
   zoomResetTitle?: string
   zoomLevel: number
+  setFilters: React.Dispatch<React.SetStateAction<MarkerFilters>>
 }
 
 function ZoomControl(props: ZoomControlProps) {
-  const { zoomInTitle, zoomResetTitle, zoomOutTitle } = props
+  const { zoomInTitle, zoomResetTitle, zoomOutTitle, setFilters } = props
 
   const map = useMap()
 
@@ -44,6 +46,12 @@ function ZoomControl(props: ZoomControlProps) {
           role="button"
           onClick={(e) => {
             map.setView([-27, -60], 3.5)
+            setFilters({
+              hideCategories: [],
+              hideTypes: [],
+              startYear: null,
+              endYear: null,
+            })
             e.preventDefault()
           }} // circle arrow symbol
         >
@@ -55,9 +63,9 @@ function ZoomControl(props: ZoomControlProps) {
 }
 
 ZoomControl.defaultProps = {
-  zoomInTitle: 'Zoom in',
-  zoomOutTitle: 'Zoom out',
-  zoomResetTitle: 'Reset zoom',
+  zoomInTitle: 'Acercar',
+  zoomOutTitle: 'Alejar',
+  zoomResetTitle: 'Restablecer',
 }
 
 export default ZoomControl

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -38,8 +38,8 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
     }
 
     const incidentList = Object.entries(data?.Incidents || {}).filter(([_, incident]) => {
-      if (filters.showCategories && !filters.showCategories.includes(incident.typeID)) return false
-      if (filters.showTypes && !filters.showTypes.includes(incident.typeID)) return false
+      if (filters.hideCategories.includes(data.Types[incident.typeID].categoryID)) return false
+      if (filters.hideTypes.includes(incident.typeID)) return false
       if (filters.startYear && new Date(incident.dateString).getFullYear() < filters.startYear) return false
       if (filters.endYear && new Date(incident.dateString).getFullYear() > filters.endYear) return false
       return true

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -1,7 +1,7 @@
 import L, { LatLngExpression, LatLngTuple } from 'leaflet'
 import { forwardRef } from 'react'
 import { useMap, Marker as LeafletMarker, LayerGroup, Polyline } from 'react-leaflet'
-import { DB, Incident } from 'types'
+import { DB, Incident, MarkerFilters } from 'types'
 
 interface IncidentLayerProps {
   data: DB
@@ -12,10 +12,11 @@ interface IncidentLayerProps {
   setTmpLocation: React.Dispatch<React.SetStateAction<Incident['location']>>
   tmpSelected: boolean
   setTmpSelected: React.Dispatch<React.SetStateAction<boolean>>
+  filters: MarkerFilters
 }
 
 const IncidentLayer = forwardRef<any, IncidentLayerProps>(
-  ({ data, selectedIncidentID, setSelectedIncidentID, isAdmin, tmpLocation, setTmpLocation, tmpSelected, setTmpSelected }, ref) => {
+  ({ data, selectedIncidentID, setSelectedIncidentID, isAdmin, tmpLocation, setTmpLocation, tmpSelected, setTmpSelected, filters }, ref) => {
     const map = useMap()
 
     map.addEventListener('dblclick', (e) => {
@@ -36,8 +37,16 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
       map.flyToBounds(bounds, { paddingTopLeft: [300, 0], duration: 3, easeLinearity: 0.5 })
     }
 
-    const incidentList = Object.entries(data?.Incidents || {})
+    const incidentList = Object.entries(data?.Incidents || {}).filter(([_, incident]) => {
+      if (filters.showCategories && !filters.showCategories.includes(incident.typeID)) return false
+      if (filters.showTypes && !filters.showTypes.includes(incident.typeID)) return false
+      if (filters.startYear && new Date(incident.dateString).getFullYear() < filters.startYear) return false
+      if (filters.endYear && new Date(incident.dateString).getFullYear() > filters.endYear) return false
+      return true
+    })
+
     const typeColors = Object.fromEntries(Object.entries(data?.Types || {}).map(([id, type]) => [id, data.Categories[type.categoryID].color]))
+
     return (
       <LayerGroup ref={ref}>
         <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 18 18">
@@ -45,7 +54,7 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
             <path
               d="M8,0C4.688,0,2,2.688,2,6c0,6,6,10,6,10s6-4,6-10C14,2.688,11.312,0,8,0z M8,8C6.344,8,5,6.656,5,5s1.344-3,3-3s3,1.344,3,3 S9.656,8,8,8z"
               stroke="#D6D6D7"
-              stroke-width="1"
+              strokeWidth="1"
               fill="none"
             />
             <path

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,6 @@ export interface DB {
 export interface MarkerFilters {
   hideCategories: (keyof DB['Categories'])[]
   hideTypes: (keyof DB['Types'])[]
-  startYear?: number
-  endYear?: number
+  startYear: number | null
+  endYear: number | null
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,8 @@ export interface DB {
 }
 
 export interface MarkerFilters {
-  showCategories?: [keyof DB['Categories']]
-  showTypes?: [keyof DB['Types']]
+  hideCategories: (keyof DB['Categories'])[]
+  hideTypes: (keyof DB['Types'])[]
   startYear?: number
   endYear?: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,10 @@ export interface DB {
     [key: string]: Incident
   }
 }
+
+export interface MarkerFilters {
+  showCategories?: [keyof DB['Categories']]
+  showTypes?: [keyof DB['Types']]
+  startYear?: number
+  endYear?: number
+}


### PR DESCRIPTION
Closes #16. Introduces a new Filter type that we can expand later, and hides markers that aren't in that filter in the IncidentLayer. One concern is that if we want to do any statistics on the filtered markers, currently they're trapped in the map, so we would need to lift that filtering up a bit.