### PR TITLE
Showing incident description on hover

### DIFF
--- a/src/components/controls/IncidentPanel.tsx
+++ b/src/components/controls/IncidentPanel.tsx
@@ -160,7 +160,7 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({
                 <span className="font-bold">Tipo de evento:</span> {data.Types[incident.typeID].name}
               </div>
               <span className="font-bold">Descripción:</span>
-              <div className="mb-6 text-shade-01">{incident.description}</div>
+              <div className="mb-6 break-words text-shade-01">{incident.description}</div>
               <div className="mb-6 text-shade-01"></div>
               {isAdmin && (
                 <>

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -82,7 +82,14 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
               },
             }}
           >
-            <Tooltip>{incident.description}</Tooltip>
+            <Tooltip direction="bottom" offset={[0, 8]}>
+              <div className="min-w-24 max-w-72 text-balance">
+                <p className="font-bold">Tipo de evento:</p>
+                <p>{data.Types[incident.typeID].name}</p>
+                <p className="font-bold">Descripción:</p>
+                <p>{incident.description}</p>
+              </div>
+            </Tooltip>
           </LeafletMarker>
         ))}
         {tmpLocation && (

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -83,7 +83,7 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
             }}
           >
             <Tooltip direction="bottom" offset={[0, 8]}>
-              <div className="min-w-24 max-w-72 text-balance">
+              <div className="min-w-24 max-w-72 text-balance break-words">
                 <p className="font-bold">Tipo de evento:</p>
                 <p>{data.Types[incident.typeID].name}</p>
                 <p className="font-bold">Descripción:</p>

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -1,6 +1,6 @@
 import L, { LatLngTuple } from 'leaflet'
 import { forwardRef } from 'react'
-import { useMap, Marker as LeafletMarker, LayerGroup } from 'react-leaflet'
+import { useMap, Marker as LeafletMarker, LayerGroup, Tooltip } from 'react-leaflet'
 import { DB, Incident, MarkerFilters } from 'types'
 
 interface IncidentLayerProps {
@@ -81,7 +81,9 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
                 }
               },
             }}
-          />
+          >
+            <Tooltip>{incident.description}</Tooltip>
+          </LeafletMarker>
         ))}
         {tmpLocation && (
           <LeafletMarker


### PR DESCRIPTION
This PR adds a feature where an incident's type and description are shown when hovering over it.

<img width="187" alt="Screenshot 2024-10-20 at 3 25 43 PM" src="https://github.com/user-attachments/assets/4163756f-64b8-40ef-9ccb-c534e437668d">

Addresses issue #50.