### PR TITLE
Update to hover popup

### DIFF
--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -84,16 +84,11 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
           >
             <Tooltip direction={incident.location.lat < map.getCenter().lat ? "top" : "bottom"} offset={[0, 8]}>
               <div className="w-max min-w-24 max-w-72 text-wrap break-words">
-                <p className="font-bold">Pais:</p>
-                <p>{incident.country}</p>
-                <p className="font-bold">Municipalidad:</p>
-                <p>{incident.municipality}</p>
-                <p className="font-bold">Fecha:</p>
-                <p>{new Date(incident.dateString).toLocaleDateString('es-ES')}</p>
-                <p className="font-bold">Actividad:</p>
-                <p>{data.Categories[data.Types[incident.typeID].categoryID].name}</p>
-                <p className="font-bold">Tipo de evento:</p>
-                <p>{data.Types[incident.typeID].name}</p>
+                <p><span className="font-bold">Pais:</span> {incident.country}</p>
+                <p><span className="font-bold">Municipalidad:</span> {incident.municipality}</p>
+                <p><span className="font-bold">Fecha:</span> {new Date(incident.dateString).toLocaleDateString('es-ES')}</p>
+                <p><span className="font-bold">Actividad:</span> {data.Categories[data.Types[incident.typeID].categoryID].name}</p>
+                <p><span className="font-bold">Tipo de evento:</span> {data.Types[incident.typeID].name}</p>
               </div>
             </Tooltip>
           </LeafletMarker>

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -82,13 +82,26 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
               },
             }}
           >
-            <Tooltip direction={incident.location.lat < map.getCenter().lat ? "top" : "bottom"} offset={[0, 8]}>
+            <Tooltip
+              direction={incident.location.lat < map.getCenter().lat ? 'top' : 'bottom'}
+              offset={[0, incident.location.lat < map.getCenter().lat ? -8 : 8]}
+            >
               <div className="w-max min-w-24 max-w-72 text-wrap break-words">
-                <p><span className="font-bold">Pais:</span> {incident.country}</p>
-                <p><span className="font-bold">Municipalidad:</span> {incident.municipality}</p>
-                <p><span className="font-bold">Fecha:</span> {new Date(incident.dateString).toLocaleDateString('es-ES')}</p>
-                <p><span className="font-bold">Actividad:</span> {data.Categories[data.Types[incident.typeID].categoryID].name}</p>
-                <p><span className="font-bold">Tipo de evento:</span> {data.Types[incident.typeID].name}</p>
+                <p>
+                  <span className="font-bold">Pais:</span> {incident.country}
+                </p>
+                <p>
+                  <span className="font-bold">Municipalidad:</span> {incident.municipality}
+                </p>
+                <p>
+                  <span className="font-bold">Fecha:</span> {new Date(incident.dateString).toLocaleDateString('es-ES')}
+                </p>
+                <p>
+                  <span className="font-bold">Actividad:</span> {data.Categories[data.Types[incident.typeID].categoryID].name}
+                </p>
+                <p>
+                  <span className="font-bold">Tipo de evento:</span> {data.Types[incident.typeID].name}
+                </p>
               </div>
             </Tooltip>
           </LeafletMarker>

--- a/src/components/layers/IncidentLayer.tsx
+++ b/src/components/layers/IncidentLayer.tsx
@@ -82,12 +82,18 @@ const IncidentLayer = forwardRef<any, IncidentLayerProps>(
               },
             }}
           >
-            <Tooltip direction="bottom" offset={[0, 8]}>
+            <Tooltip direction={incident.location.lat < map.getCenter().lat ? "top" : "bottom"} offset={[0, 8]}>
               <div className="w-max min-w-24 max-w-72 text-wrap break-words">
+                <p className="font-bold">Pais:</p>
+                <p>{incident.country}</p>
+                <p className="font-bold">Municipalidad:</p>
+                <p>{incident.municipality}</p>
+                <p className="font-bold">Fecha:</p>
+                <p>{new Date(incident.dateString).toLocaleDateString('es-ES')}</p>
+                <p className="font-bold">Actividad:</p>
+                <p>{data.Categories[data.Types[incident.typeID].categoryID].name}</p>
                 <p className="font-bold">Tipo de evento:</p>
                 <p>{data.Types[incident.typeID].name}</p>
-                <p className="font-bold">Descripción:</p>
-                <p>{incident.description}</p>
               </div>
             </Tooltip>
           </LeafletMarker>


### PR DESCRIPTION
Fixes #58

Update the hover popup to display specified fields and remove the incident description.

* Update `Tooltip` content to include the fields Pais, Municipalidad, Fecha (day/month/year), Actividad, and Tipo de evento.
* Remove the incident description from the `Tooltip` content.
* Adjust the `Tooltip` direction to display on the top of the marker when the marker is on the bottom of the screen, and the top otherwise.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DSSD-Madison/Red-CORAL/issues/58?shareId=2be5fc8f-694b-4e54-9233-1dbf4fb96676).