### PR TITLE
Open filter popup immediately when it’s added

### DIFF
--- a/src/components/filters/BaseFilter.tsx
+++ b/src/components/filters/BaseFilter.tsx
@@ -13,12 +13,13 @@ import {
   arrow,
   size,
 } from '@floating-ui/react'
+import { LucideChevronDown, LucideChevronRight } from 'lucide-react'
 
 /**
  * Represents a filter chip that can be clicked to open a dropdown with more options. Handles the dropdown state and visibility.
  */
 const BaseFilter = ({ icon, text, children, scrollOverflow }: { icon: any; text: string; children: ReactNode; scrollOverflow?: boolean }) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(true)
   const arrowRef = useRef(null)
 
   const { refs, floatingStyles, context } = useFloating({
@@ -56,6 +57,7 @@ const BaseFilter = ({ icon, text, children, scrollOverflow }: { icon: any; text:
       >
         <icon.type size={16} strokeWidth={1} />
         <span>{text}</span>
+        <span>{isOpen ? <LucideChevronDown size={16} strokeWidth={1} /> : <LucideChevronRight size={16} strokeWidth={1} />}</span>
       </div>
       {isOpen && (
         <FloatingFocusManager context={context} modal={false}>


### PR DESCRIPTION
Fixes #89

Set the initial state of `isOpen` to `true` in `BaseFilter` component to default it to being open.

Add a caret icon to the `BaseFilter` component to imply expandability.
* Import `LucideChevronDown` and `LucideChevronRight` from 'lucide-react'.
* Add a span element to display the appropriate caret icon based on the `isOpen` state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/DSSD-Madison/Red-CORAL/pull/93?shareId=78ec1c99-3866-4175-9fc8-481658cb4bc7).