### PR TITLE
Stats filters refactor

### DIFF
--- a/src/components/StatisticsFilterBar.tsx
+++ b/src/components/StatisticsFilterBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import AddFilter from './filters/AddFilter'
-import { filterDispatchType, filterType } from '@/pages/StatsDashboard'
+import { filterDispatchType, filterType } from '@/filters/filterReducer'
+import { filterComponents } from '@/filters/filterReducer'
 
 type statsFilterProps = {
   filters: filterType[]
@@ -9,11 +10,15 @@ type statsFilterProps = {
 
 const StatisticsFilterBar = ({ filters, dispatchFilters }: statsFilterProps) => {
   return (
-    <div className="overflow-x-auto border-b border-t border-gray-400 text-sm">
-      <div className="flex h-8 w-max items-center justify-start gap-2">
+    <div className="overflow-x-auto border-b border-t border-gray-400 py-2 text-sm">
+      <div className="flex w-max flex-wrap items-center justify-start gap-2">
         {filters.map((filter) => {
-          const FilterComponent = filter.component
-          return <FilterComponent key={filter.id} id={filter.id} dispatch={dispatchFilters} operation={filter.operation} state={filter.state} />
+          const FilterComponent = filterComponents[filter.type]
+          if (!FilterComponent) {
+            console.error(`No component found for filter type: ${filter.type}`) // This shouldn't happen
+            return null
+          }
+          return <FilterComponent key={filter.id} id={filter.id} dispatch={dispatchFilters} state={filter.state} />
         })}
         <AddFilter dispatch={dispatchFilters} />
       </div>

--- a/src/components/filters/AddFilter.tsx
+++ b/src/components/filters/AddFilter.tsx
@@ -1,8 +1,5 @@
 import { useRef, useState } from 'react'
-import DateFilter from './DateFilter'
-import DescFilter from './DescFilter'
-import LatLongFilter from './LatLongFilter'
-import { filterDispatchType, filterProps } from '@/pages/StatsDashboard'
+import { filterDispatchType, filterType } from '@/filters/filterReducer'
 import { LucideCalendar, LucideGlobe, LucideMapPin, LucidePlus, LucideTags, LucideText } from 'lucide-react'
 import {
   useFloating,
@@ -17,46 +14,43 @@ import {
   FloatingArrow,
   arrow,
 } from '@floating-ui/react'
-import CountryFilter from './CountryFilter'
-import CategoryFilter from './CategoryFilter'
-
 interface FilterInfo {
   name: string
   icon: any
-  component: React.FC<filterProps>
   description: string
+  type: filterType['type']
 }
 
 const possibleFilters: FilterInfo[] = [
   {
     name: 'Actividades',
     icon: LucideTags,
-    component: CategoryFilter,
     description: 'Filtrar por actividades y tipos de eventos',
+    type: 'category',
   },
   {
     name: 'Fecha',
     icon: LucideCalendar,
-    component: DateFilter,
     description: 'Filtrar por fecha',
+    type: 'date',
   },
   {
     name: 'Latitud/Longitud',
     icon: LucideMapPin,
-    component: LatLongFilter,
     description: 'Filtrar por ubicación',
+    type: 'latlong',
   },
   {
     name: 'Áreas',
     icon: LucideGlobe,
-    component: CountryFilter,
     description: 'Filtrar por áreas geográficas',
+    type: 'country',
   },
   {
     name: 'Descripción',
     icon: LucideText,
-    component: DescFilter,
     description: 'Filtrar por palabras clave en la descripción',
+    type: 'desc',
   },
 ]
 
@@ -64,7 +58,7 @@ function NewFilterButton({ filter, dispatch }: { filter: FilterInfo; dispatch: R
   return (
     <button
       className="block w-full rounded-md px-2 py-1 text-left hover:bg-black/5"
-      onClick={() => dispatch({ type: 'ADD_FILTER', payload: { component: filter.component } })}
+      onClick={() => dispatch({ type: 'ADD_FILTER', payload: { type: filter.type } })}
     >
       <span className="flex items-center">
         {filter.icon && <filter.icon size={12} className="mr-1" />}

--- a/src/components/filters/CategoryFilter.tsx
+++ b/src/components/filters/CategoryFilter.tsx
@@ -1,14 +1,20 @@
-import { filterProps } from '@/pages/StatsDashboard'
+import { filterProps } from '@/filters/filterReducer'
 import BaseFilter from './BaseFilter'
 import { LucideTags, LucideTrash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { Incident } from '@/types'
 import { useDB } from '@/context/DBContext'
 
-const CategoryFilter = ({ id, dispatch }: filterProps) => {
+interface CategoryFilterState extends filterProps {
+  state?: {
+    hiddenCategories: string[]
+    hiddenTypes: string[]
+  }
+}
+
+const CategoryFilter = ({ id, dispatch, state }: CategoryFilterState) => {
   const { db } = useDB()
-  const [hiddenCategories, setHiddenCategories] = useState<string[]>([])
-  const [hiddenTypes, setHiddenTypes] = useState<string[]>([])
+  const [hiddenCategories, setHiddenCategories] = useState<string[]>(state?.hiddenCategories || [])
+  const [hiddenTypes, setHiddenTypes] = useState<string[]>(state?.hiddenTypes || [])
 
   const typesByCategory = useMemo(() => {
     return Object.entries(db.Types).reduce(
@@ -54,19 +60,6 @@ const CategoryFilter = ({ id, dispatch }: filterProps) => {
       setHiddenCategories(Object.keys(db.Categories))
       setHiddenTypes(Object.keys(db.Types))
     }
-  }
-
-  const applyFilters = () => {
-    const incidentNotHidden = (incident: Incident) =>
-      !hiddenCategories.includes(db.Types[incident.typeID as string].categoryID as string) && !hiddenTypes.includes(incident.typeID as string)
-
-    dispatch({
-      type: 'UPDATE_FILTER',
-      payload: {
-        id: id,
-        operation: incidentNotHidden,
-      },
-    })
   }
 
   const removeThisFilter = () => {
@@ -128,7 +121,18 @@ const CategoryFilter = ({ id, dispatch }: filterProps) => {
             </div>
           </details>
         ))}
-        <button onClick={applyFilters} className="mt-4 rounded bg-blue-500 px-2 py-1 text-white">
+        <button
+          onClick={() =>
+            dispatch({
+              type: 'UPDATE_FILTER',
+              payload: {
+                id: id,
+                state: { hiddenCategories, hiddenTypes },
+              },
+            })
+          }
+          className="mt-4 rounded bg-blue-500 px-2 py-1 text-white"
+        >
           Aplicar
         </button>
       </div>

--- a/src/components/filters/CountryFilter.tsx
+++ b/src/components/filters/CountryFilter.tsx
@@ -1,15 +1,22 @@
-import { filterProps } from '@/pages/StatsDashboard'
+import { filterProps } from '@/filters/filterReducer'
 import BaseFilter from './BaseFilter'
 import { LucideGlobe, LucideTrash2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { Incident } from '@/types'
 import { useDB } from '@/context/DBContext'
 
-const CountryFilter = ({ id, dispatch }: filterProps) => {
+interface CountryFilterState extends filterProps {
+  state?: {
+    hiddenCountries: string[]
+    hiddenDepartments: string[]
+    hiddenMunicipalities: string[]
+  }
+}
+
+const CountryFilter = ({ id, dispatch, state }: CountryFilterState) => {
   const { db } = useDB()
-  const [hiddenCountries, setHiddenCountries] = useState<string[]>([])
-  const [hiddenDepartments, setHiddenDepartments] = useState<string[]>([])
-  const [hiddenMunicipalities, setHiddenMunicipalities] = useState<string[]>([])
+  const [hiddenCountries, setHiddenCountries] = useState<string[]>(state?.hiddenCountries || [])
+  const [hiddenDepartments, setHiddenDepartments] = useState<string[]>(state?.hiddenDepartments || [])
+  const [hiddenMunicipalities, setHiddenMunicipalities] = useState<string[]>(state?.hiddenMunicipalities || [])
 
   const departmentsByCountry = useMemo(() => {
     return Object.entries(db.filterBounds.locations).reduce(
@@ -83,21 +90,6 @@ const CountryFilter = ({ id, dispatch }: filterProps) => {
         )
       )
     }
-  }
-
-  const applyFilters = () => {
-    const incidentNotHidden = (incident: Incident) =>
-      !hiddenCountries.includes(incident.country) &&
-      !hiddenDepartments.includes(`${incident.country} - ${incident.department}`) &&
-      !hiddenMunicipalities.includes(`${incident.country} - ${incident.department} - ${incident.municipality}`)
-
-    dispatch({
-      type: 'UPDATE_FILTER',
-      payload: {
-        id: id,
-        operation: incidentNotHidden,
-      },
-    })
   }
 
   const removeThisFilter = () => {
@@ -181,7 +173,18 @@ const CountryFilter = ({ id, dispatch }: filterProps) => {
             </div>
           </details>
         ))}
-        <button onClick={applyFilters} className="mt-4 rounded bg-blue-500 px-2 py-1 text-white">
+        <button
+          onClick={() =>
+            dispatch({
+              type: 'UPDATE_FILTER',
+              payload: {
+                id: id,
+                state: { hiddenCountries, hiddenDepartments, hiddenMunicipalities },
+              },
+            })
+          }
+          className="mt-4 rounded bg-blue-500 px-2 py-1 text-white"
+        >
           Aplicar
         </button>
       </div>

--- a/src/components/filters/DateFilter.tsx
+++ b/src/components/filters/DateFilter.tsx
@@ -1,7 +1,7 @@
-import { filterProps } from '@/pages/StatsDashboard'
+import { filterProps } from '@/filters/filterReducer'
 import BaseFilter from './BaseFilter'
 import { LucideCalendar, LucideChevronDown, LucideChevronRight, LucideTrash2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   useFloating,
   offset,
@@ -22,6 +22,7 @@ enum DateFilterOption {
   IS_AFTER = 'es posterior',
   IS_BETWEEN = 'es entre',
 }
+
 const possibleDateFilterOptions: DateFilterOption[] = [
   DateFilterOption.IS,
   DateFilterOption.IS_BEFORE,
@@ -29,37 +30,20 @@ const possibleDateFilterOptions: DateFilterOption[] = [
   DateFilterOption.IS_BETWEEN,
 ]
 
-const FilterDate = ({ id, dispatch }: filterProps) => {
-  const [date1, setDate1] = useState('')
-  const [date2, setDate2] = useState('')
-  const [selectedDateFilter, setSelectedDateFilter] = useState(DateFilterOption.IS_BETWEEN)
-  const [isDateFilterSelectOpen, setIsDateFilterSelectOpen] = useState(false)
+interface DateFilterState extends filterProps {
+  state?: {
+    date1: string
+    date2: string
+    selectedDateFilter: DateFilterOption
+    isDateFilterSelectOpen: boolean
+  }
+}
 
-  useEffect(() => {
-    if (!date1) {
-      return
-    }
-    switch (selectedDateFilter) {
-      case DateFilterOption.IS:
-        dispatch({ type: 'UPDATE_FILTER', payload: { id: id, operation: (incident) => incident.dateString === date1 } })
-        break
-      case DateFilterOption.IS_BEFORE:
-        dispatch({ type: 'UPDATE_FILTER', payload: { id: id, operation: (incident) => incident.dateString < date1 } })
-        break
-      case DateFilterOption.IS_AFTER:
-        dispatch({ type: 'UPDATE_FILTER', payload: { id: id, operation: (incident) => incident.dateString > date1 } })
-        break
-      case DateFilterOption.IS_BETWEEN:
-        if (!date2) {
-          return
-        }
-        dispatch({
-          type: 'UPDATE_FILTER',
-          payload: { id: id, operation: (incident) => date1 <= incident.dateString && incident.dateString <= date2 },
-        })
-        break
-    }
-  }, [date1, date2, selectedDateFilter])
+const FilterDate = ({ id, dispatch, state }: DateFilterState) => {
+  const [date1, setDate1] = useState(state?.date1 || '')
+  const [date2, setDate2] = useState(state?.date2 || '')
+  const [selectedDateFilter, setSelectedDateFilter] = useState(state?.selectedDateFilter || DateFilterOption.IS_BETWEEN)
+  const [isDateFilterSelectOpen, setIsDateFilterSelectOpen] = useState(state?.isDateFilterSelectOpen || false)
 
   const removeThisFilter = () => {
     dispatch({ type: 'REMOVE_FILTER', payload: { id: id } })
@@ -138,6 +122,20 @@ const FilterDate = ({ id, dispatch }: filterProps) => {
           </>
         )}
       </div>
+      <button
+        onClick={() =>
+          dispatch({
+            type: 'UPDATE_FILTER',
+            payload: {
+              id: id,
+              state: { date1, date2, selectedDateFilter, isDateFilterSelectOpen },
+            },
+          })
+        }
+        className="mt-4 rounded bg-blue-500 px-2 py-1 text-white"
+      >
+        Aplicar
+      </button>
     </BaseFilter>
   )
 }

--- a/src/components/filters/DescFilter.tsx
+++ b/src/components/filters/DescFilter.tsx
@@ -1,21 +1,15 @@
-import { filterProps } from '@/pages/StatsDashboard'
+import { filterProps } from '@/filters/filterReducer'
 import BaseFilter from './BaseFilter'
 import { LucideCalendar, LucideTrash2 } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
-const FilterDesc = ({ id, dispatch }: filterProps) => {
-  const [search, setSearch] = useState('')
-
-  useEffect(() => {
-    const lowercaseSearch = search.toLowerCase()
-    dispatch({
-      type: 'UPDATE_FILTER',
-      payload: {
-        id: id,
-        operation: (incident) => incident.description.toLowerCase().includes(lowercaseSearch),
-      },
-    })
-  }, [search])
+interface DescFilterState extends filterProps {
+  state?: {
+    search: string
+  }
+}
+const FilterDesc = ({ id, dispatch, state }: DescFilterState) => {
+  const [search, setSearch] = useState(state?.search || '')
 
   const removeThisFilter = () => {
     dispatch({ type: 'REMOVE_FILTER', payload: { id: id } })
@@ -27,6 +21,20 @@ const FilterDesc = ({ id, dispatch }: filterProps) => {
         <LucideTrash2 size={20} />
       </button>
       <input type="text" onChange={(e) => setSearch(e.target.value)} value={search} className="mr-6 rounded-md border border-gray-300 p-1" />
+      <button
+        onClick={() =>
+          dispatch({
+            type: 'UPDATE_FILTER',
+            payload: {
+              id: id,
+              state: { search: search },
+            },
+          })
+        }
+        className="mt-4 rounded bg-blue-500 px-2 py-1 text-white"
+      >
+        Aplicar
+      </button>
     </BaseFilter>
   )
 }

--- a/src/components/filters/LatLongFilter.tsx
+++ b/src/components/filters/LatLongFilter.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import { filterProps } from '@/pages/StatsDashboard'
+import React, { useState } from 'react'
+import { filterProps } from '@/filters/filterReducer'
 import BaseFilter from './BaseFilter'
 import { LucideMapPin, LucideTrash2 } from 'lucide-react'
 
@@ -12,30 +12,18 @@ export const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2
   return 6371 * c
 }
 
-const LatLongFilter: React.FC<filterProps> = ({ id, dispatch }) => {
-  const [latitude, setLatitude] = useState('')
-  const [longitude, setLongitude] = useState('')
-  const [radius, setRadius] = useState('')
+interface LatLongFilterState extends filterProps {
+  state?: {
+    latitude: string
+    longitude: string
+    radius: string
+  }
+}
 
-  useEffect(() => {
-    const lat = parseFloat(latitude)
-    const lon = parseFloat(longitude)
-    const rad = parseFloat(radius)
-
-    if (!isNaN(lat) && !isNaN(lon) && !isNaN(rad)) {
-      dispatch({
-        type: 'UPDATE_FILTER',
-        payload: {
-          id: id,
-          operation: (incident) => {
-            if (!incident.location) return false
-            const { lat: incLat, lng: incLon } = incident.location
-            return calculateDistance(lat, lon, incLat, incLon) <= rad
-          },
-        },
-      })
-    }
-  }, [latitude, longitude, radius, id, dispatch])
+const LatLongFilter: React.FC<filterProps> = ({ id, dispatch, state }: LatLongFilterState) => {
+  const [latitude, setLatitude] = useState(state?.latitude || '')
+  const [longitude, setLongitude] = useState(state?.longitude || '')
+  const [radius, setRadius] = useState(state?.radius || '')
 
   const removeThisFilter = () => {
     dispatch({ type: 'REMOVE_FILTER', payload: { id } })
@@ -68,6 +56,20 @@ const LatLongFilter: React.FC<filterProps> = ({ id, dispatch }) => {
         onChange={(e) => setRadius(e.target.value)}
         className="rounded-md border border-gray-300 p-1"
       />
+      <button
+        onClick={() =>
+          dispatch({
+            type: 'UPDATE_FILTER',
+            payload: {
+              id: id,
+              state: { latitude, longitude, radius },
+            },
+          })
+        }
+        className="mt-4 rounded bg-blue-500 px-2 py-1 text-white"
+      >
+        Aplicar
+      </button>
     </BaseFilter>
   )
 }

--- a/src/filters/filterReducer.ts
+++ b/src/filters/filterReducer.ts
@@ -1,0 +1,114 @@
+import { DB, Incident } from 'types'
+import React from 'react'
+import CategoryFilter from '@/components/filters/CategoryFilter'
+import CountryFilter from '@/components/filters/CountryFilter'
+import DateFilter from '@/components/filters/DateFilter'
+import DescFilter from '@/components/filters/DescFilter'
+import LatLongFilter, { calculateDistance } from '@/components/filters/LatLongFilter'
+
+export type filterDispatchType = { type: 'ADD_FILTER' | 'REMOVE_FILTER' | 'UPDATE_FILTER'; payload: Partial<filterType> }
+
+export type filterProps = {
+  id: number
+  dispatch: React.Dispatch<filterDispatchType>
+  state?: any
+}
+
+export type filterType = {
+  id: number
+  type: 'category' | 'country' | 'date' | 'desc' | 'latlong'
+  state?: any
+}
+
+type reducerType = {
+  index: number
+  filters: filterType[]
+}
+
+export const initialFilterState: reducerType = {
+  index: 0,
+  filters: [],
+}
+
+export const filterReducer = (state: reducerType, action: filterDispatchType): reducerType => {
+  switch (action.type) {
+    case 'ADD_FILTER': {
+      const id = state.index
+      const newFilter = { id, ...action.payload } as filterType
+      return { index: state.index + 1, filters: [...state.filters, newFilter] }
+    }
+    case 'REMOVE_FILTER':
+      return { ...state, filters: state.filters.filter((filter) => filter.id !== action.payload.id) }
+    case 'UPDATE_FILTER':
+      return { ...state, filters: state.filters.map((filter) => (filter.id === action.payload.id ? { ...filter, ...action.payload } : filter)) }
+    default:
+      return state
+  }
+}
+
+export const filterComponents: { [key: string]: React.FC<filterProps> } = {
+  category: CategoryFilter,
+  country: CountryFilter,
+  date: DateFilter,
+  desc: DescFilter,
+  latlong: LatLongFilter,
+}
+
+export const filterOperations: { [key: string]: (incident: Incident, state: any, db: DB) => boolean } = {}
+
+filterOperations['category'] = (incident: Incident, state: any, db: DB) => {
+  if (!state) return true
+  const { hiddenCategories, hiddenTypes } = state
+  return !hiddenCategories.includes(db.Types[incident.typeID as string].categoryID as string) && !hiddenTypes.includes(incident.typeID as string)
+}
+
+filterOperations['country'] = (incident: Incident, state: any) => {
+  if (!state) return true
+  const { hiddenCountries, hiddenDepartments, hiddenMunicipalities } = state
+  return (
+    !hiddenCountries.includes(incident.country) &&
+    !hiddenDepartments.includes(`${incident.country} - ${incident.department}`) &&
+    !hiddenMunicipalities.includes(`${incident.country} - ${incident.department} - ${incident.municipality}`)
+  )
+}
+
+filterOperations['date'] = (incident: Incident, state: any) => {
+  if (!state) return true
+  const { date1, date2, selectedDateFilter } = state
+  switch (selectedDateFilter) {
+    case 'es':
+      return incident.dateString === date1
+    case 'es anterior':
+      return incident.dateString < date1
+    case 'es posterior':
+      return incident.dateString > date1
+    case 'es entre':
+      if (!date2) {
+        return false
+      }
+      return date1 <= incident.dateString && incident.dateString <= date2
+    default:
+      return true
+  }
+}
+
+filterOperations['desc'] = (incident: Incident, state: any) => {
+  if (!state) return true
+  const { search } = state
+  return incident.description.toLowerCase().includes(search.toLowerCase())
+}
+
+filterOperations['latlong'] = (incident: Incident, state: any) => {
+  if (!state) return true
+  const { latitude, longitude, radius } = state
+  const lat = parseFloat(latitude)
+  const lon = parseFloat(longitude)
+  const rad = parseFloat(radius)
+
+  if (!isNaN(lat) && !isNaN(lon) && !isNaN(rad)) {
+    if (!incident.location) return false
+    const { lat: incLat, lng: incLon } = incident.location
+    return calculateDistance(lat, lon, incLat, incLon) <= rad
+  }
+  return true
+}

--- a/src/pages/StatsDashboard.tsx
+++ b/src/pages/StatsDashboard.tsx
@@ -10,60 +10,12 @@ import PieChart from '@/components/graphs/PieChart'
 import StatisticsFilterMap from '@/components/StatisticsFilterMap'
 import { LucideMap } from 'lucide-react'
 import { useDB } from '@/context/DBContext'
-
-export type filterDispatchType = { type: 'ADD_FILTER' | 'REMOVE_FILTER' | 'UPDATE_FILTER'; payload: Partial<filterType> }
-
-export type filterProps = {
-  id: number
-  dispatch: React.Dispatch<filterDispatchType>
-  operation?: (incident: Incident) => boolean
-  state?: any
-}
-
-export type filterType = {
-  id: number
-  component: React.FC<filterProps>
-  state?: any
-  operation?: (incident: Incident) => boolean
-}
-
-type filterState = {
-  index: number
-  filters: filterType[]
-}
-
-/**
- * The idea is that the user can add and layer filters on top of each other to filter the incidents.
- * Each filter has...
- * - an id - a unique identifier for the filter used to remove or update it
- * - a component that is displayed in the filter bar, displays the state of its filter, and can be clicked on to modify or remove the filter.
- * - a state - some filters might need to store some state, maybe.
- * - an operation - a function that takes an incident and returns a boolean. If the incident passes the filter, the function should return true.
- *
- * The filter bar is a horizontal bar that displays all the filters that have been added. It also has a button to add a new filter from a list.
- */
-const filterReducer = (state: filterState, action: filterDispatchType) => {
-  let newState = state
-  switch (action.type) {
-    case 'ADD_FILTER':
-      const id = state.index
-      const newFilter = { id, ...action.payload } as filterType
-      newState = { index: state.index + 1, filters: [...state.filters, newFilter] }
-      break
-    case 'REMOVE_FILTER':
-      newState = { ...state, filters: state.filters.filter((filter) => filter.id !== action.payload.id) }
-      break
-    case 'UPDATE_FILTER':
-      newState = { ...state, filters: state.filters.map((filter) => (filter.id === action.payload.id ? { ...filter, ...action.payload } : filter)) }
-      break
-  }
-  return newState
-}
+import { filterOperations, filterReducer, initialFilterState } from '@/filters/filterReducer'
 
 const StatsDashboard: React.FC = () => {
   const { db } = useDB()
   const [isShowingMap, setIsShowingMap] = useState(false)
-  const [filters, dispatchFilters] = useReducer(filterReducer, { index: 0, filters: [] })
+  const [filters, dispatchFilters] = useReducer(filterReducer, initialFilterState)
   const incidents: [string, Incident][] = Object.entries(db.Incidents)
   const sortedIncidents = useMemo(
     () =>
@@ -73,7 +25,7 @@ const StatsDashboard: React.FC = () => {
     [incidents]
   )
   const filteredIncidents = useMemo(
-    () => sortedIncidents.filter(([, incident]) => filters.filters.every((filter) => (filter.operation ? filter.operation(incident) : true))),
+    () => sortedIncidents.filter(([, incident]) => filters.filters.every((filter) => filterOperations[filter.type](incident, filter.state, db))),
     [sortedIncidents, filters]
   )
   const filteredBounds = calculateBounds(Object.fromEntries(filteredIncidents))


### PR DESCRIPTION
Right now, filters are a little horrific- they send an arbitrary function up to the reducer, and all their state is stored inside the component. It would be nice if they sent their state up to the reducer and the reducer figured out how to turn that into a true/false judgement on an incident, that way we could serialize the whole reducer state into JSON and save/restore it when needed.

- [x] Make filter state serializable to JSON

This will make it much easier to work on #78 and #101.